### PR TITLE
Update README with link to actual post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-app-integration-tests-sample
 Sample integration tests implementation for a common react app structure
 
-[Read more about the the project and reasoning here.](https://www.toptal.com/blog/ADD_ARTICLE_LINK_HERE_WHEN_PUBLISHED)
+[Read more about the the project and reasoning here.](https://www.toptal.com/react/react-testing-library-tutorial)
 
 ## App implementation details
 


### PR DESCRIPTION
I came across the article on Toptal about React Integration testing. I was really happy to see the example repo. I noticed the README had a link that looked to be meant for the article, but had a placeholder link in it. I updated the link in the README so others who come across the repo can find the article.